### PR TITLE
term_setup: always restore initial stty settings on exit

### DIFF
--- a/shellect
+++ b/shellect
@@ -83,6 +83,16 @@ term_reset() {
     stty "$stty"
 }
 
+term_init() {
+    term_setup
+    stty_init="$stty"
+}
+
+term_exit() {
+    stty="$stty_init"
+    term_reset
+}
+
 old_save() {
     old_num=$num
     old_y=$y
@@ -717,7 +727,7 @@ key() {
                 ;;
 
             q?) # q
-                term_reset
+                term_exit
                 exit 0
                 ;;
             "$esc_c"*) esc=1 ;;
@@ -733,11 +743,11 @@ main() {
 
     set -e
 
-    trap 'term_reset; exit 0' INT QUIT
+    trap 'term_exit; exit 0' INT QUIT
     trap 'term_getsize; term_setup; y=1; yy=1; y2=$top; pos=$top; redraw "$@"' WINCH
 
     term_getsize
-    term_setup
+    term_init
     y=1 yy=1 y2=$top pos=$top
 
     IFS=${ifs:=$nl}


### PR DESCRIPTION
term_setup/term_reset are used not only on start and on exit, but also when switching from selection mode to search mode and back.

This has the unintended side effect of clobbering the stty variable with the settings of selection mode when search mode is entered and thus shellect returns to shell with -echo.

Fix this by defining two wrappers term_init and term_exit that are exclusively called on startup and teardown respectively and are unaffected by term_setup being called in-between.